### PR TITLE
Fixed auto update settings

### DIFF
--- a/src/main/kotlin/com/github/mr3zee/kotlinPlugins/KotlinPluginsConfigurable.kt
+++ b/src/main/kotlin/com/github/mr3zee/kotlinPlugins/KotlinPluginsConfigurable.kt
@@ -449,6 +449,8 @@ internal class KotlinPluginsConfigurable(private val project: Project) : Configu
         enableAnalyzerCheckBox.isSelected = local.exceptionAnalyzerEnabled
         autoDisablePluginsCheckBox.isEnabled = enableAnalyzerCheckBox.isSelected
         autoDisablePluginsCheckBox.isSelected = local.autoDiablePlugins
+        autoUpdateCheckBox.isSelected = local.autoUpdateEnabled
+        autoUpdateInterval.number = local.autoUpdateInterval
     }
 
     // region Repository actions


### PR DESCRIPTION
The auto-update settings (enabled checkbox & interval) reset each time the settings UI is opened. This fixes the issue.